### PR TITLE
Fix a typo on shape-swirl.md

### DIFF
--- a/api/shape-swirl.md
+++ b/api/shape-swirl.md
@@ -8,7 +8,7 @@
 Full API reference:
 
 ```javascript
-const shape = new mojs.Shape({
+const shapeSwirl = new mojs.ShapeSwirl({
 
   // ∆ :: Diviation size of sine. {Number}
   swirlSize:          10,


### PR DESCRIPTION
Hey Oleg!

First of all, thanks for the awesome work!!.

This PR updates `shape-swirl.md` to use the `ShapeSwirl` constructor instead of the
`Shape` constructor for the code example.