### PR TITLE
Restore tweens function fix

### DIFF
--- a/js/tween/tweener.babel.js
+++ b/js/tween/tweener.babel.js
@@ -8,7 +8,7 @@ class Tweener {
     this._listenVisibilityChange();
     return this;
   }
-  
+
   _vars () {
     this.tweens = [];
     this._loop = this._loop.bind(this);
@@ -134,11 +134,13 @@ class Tweener {
     @private
   */
   _restorePlayingTweens () {
-    for (let i = 0; i < this._savedTweens.length; i++ ) {
-      this._savedTweens[i].resume();
+    if (this._savedTweens !== undefined && this._savedTweens.constructor === Array && this._savedTweens.length) {
+      for (let i = 0; i < this._savedTweens.length; i++ ) {
+        this._savedTweens[i].resume();
+      }
     }
   }
 }
-  
+
 var t = new Tweener
 export default t;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "homepage": "https://github.com/legomushroom/mojs",
   "dependencies": {
-    "babel-runtime": "^6.5.0"
+    "babel-runtime": "^6.5.0",
+    "gulp-babel": "^6.1.2"
   },
   "devDependencies": {
     "6to5-loader": "^3.0.0",

--- a/spec/tween/tweener.coffee
+++ b/spec/tween/tweener.coffee
@@ -172,7 +172,10 @@ describe 'Tweener ->', ->
       , 2*duration
 
   isPageVisibility = ->
-    return (typeof document.hidden != "undefined") or (typeof document.mozHidden != "undefined") or (typeof document.msHidden != "undefined") or (typeof document.webkitHidden != "undefined")
+    return (typeof document.hidden != "undefined") or
+      (typeof document.mozHidden != "undefined") or
+      (typeof document.msHidden != "undefined") or
+      (typeof document.webkitHidden != "undefined")
 
   describe '_listenVisibilityChange method ->', ->
     if !isPageVisibility() then return
@@ -294,6 +297,11 @@ describe 'Tweener ->', ->
       expect(tw1.resume).toHaveBeenCalled()
       expect(tw2.resume).toHaveBeenCalled()
       expect(tw3.resume).toHaveBeenCalled()
+
+    it 'should check for empty array before resuming', ->
+      t.tweens = []
+
+      expect(-> t._restorePlayingTweens()).not.toThrow()
 
   describe '_onVisibilityChange method ->', ->
     it 'should call _savePlayingTweens if hidden', ->

--- a/spec/tween/tweener.js
+++ b/spec/tween/tweener.js
@@ -341,7 +341,7 @@
         expect(t.tweens[1]).toBe(tw2);
         return expect(t.tweens[2]).toBe(tw3);
       });
-      return it('should call `resume` on each tween', function() {
+      it('should call `resume` on each tween', function() {
         var tw1, tw2, tw3;
         tw1 = new Tween;
         tw1._setStartTime();
@@ -358,6 +358,12 @@
         expect(tw1.resume).toHaveBeenCalled();
         expect(tw2.resume).toHaveBeenCalled();
         return expect(tw3.resume).toHaveBeenCalled();
+      });
+      return it('should check for empty array before resuming', function() {
+        t.tweens = [];
+        return expect(function() {
+          return t._restorePlayingTweens();
+        }).not.toThrow();
       });
     });
     return describe('_onVisibilityChange method ->', function() {


### PR DESCRIPTION
`_restorePlayingTweens` was throwing an error because `this._savedTweens` was sometimes `undefined` (I'm not sure what caused that, but this check should have been done either way!)

Also small things:
+ added gulp-babel to dependencies
+ fixed test line length error in spec/tweener.coffee