### PR TITLE
Update docs for isYoyo.

### DIFF
--- a/api/html.md
+++ b/api/html.md
@@ -77,7 +77,7 @@ const html = new mojs.Html({
   // Speed of the tween {Number}[0..∞]
   speed:          1,
   // If the progress should be flipped on repeat animation end {Boolean}
-  yoyo:           false,
+  isYoyo:         false,
   // Easing function {String, Function}[ easing name, path coordinates, bezier string, easing function ]
   easing:         'sin.out',
   // Easing function for backward direction of the tween animation (fallbacks to `easing`) {String, Function}[ easing name, path coordinates, bezier string, easing function ]

--- a/api/shape.md
+++ b/api/shape.md
@@ -120,7 +120,7 @@ const shape = new mojs.Shape({
   // Speed of the tween {Number}[0..∞]
   speed:          1,
   // If the progress should be flipped on repeat animation end {Boolean}
-  yoyo:           false,
+  isYoyo:         false,
   // Easing function {String, Function}[ easing name, path coordinates, bezier string, easing function ]
   easing:         'sin.out',
   // Easing function for backward direction of the tween animation (fallbacks to `easing`) {String, Function}[ easing name, path coordinates, bezier string, easing function ]

--- a/api/tweens/tween.md
+++ b/api/tweens/tween.md
@@ -20,7 +20,7 @@ const tween = new mojs.Tween({
   // Speed of the tween {Number}[0..∞]
   speed:          1,
   // If the progress should be flipped on repeat animation end {Boolean}
-  yoyo:           false,
+  isYoyo:         false,
   // Easing function {String, Function}[ easing name, path coordinates, bezier string, easing function ]
   easing:         'sin.out',
   // Easing function for backward direction of the tween animation (fallbacks to `easing`) {String, Function}[ easing name, path coordinates, bezier string, easing function ]


### PR DESCRIPTION
Per @legomushroom, all boolean options are now prefixed with `is`.

This updates the documentation for the `isYoyo` attribute. This only affects documentation. I also found remaining references to `yoyo` in the following files that I didn’t feel comfortable modifying myself at my current understanding of the codebase:

- [ ] `build/mo.js`
- [ ] `js/motion-path.coffee`
- [ ] `js/spriter.babel.js`
- [ ] `spec/motion-path.js`
- [ ] `spec/tunable.coffee`
- [ ] `spec/thenable.js`
- [ ] `spec/tunable.js`