### PR TITLE
Fixes missing bounce easing reference

### DIFF
--- a/api/easing/base-functions.md
+++ b/api/easing/base-functions.md
@@ -59,9 +59,9 @@ The full list of base functions:
   'elastic.out'
   'elastic.inout'
 
-  'circ.in'
-  'circ.out'
-  'circ.inout'
+  'bounce.in'
+  'bounce.out'
+  'bounce.inout'
 
 ```
 


### PR DESCRIPTION
The bounce easing reference is missing in the api documentation.